### PR TITLE
Stuff talky needs

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,25 @@
+{
+    "asi": false,
+    "expr": true,
+    "loopfunc": true,
+    "curly": false,
+    "evil": true,
+    "white": true,
+    "undef": true,
+    "browser": true,
+    "es5": true,
+    "predef": [
+        "$",
+        "FormBot",
+        "socket",
+        "confirm",
+        "alert",
+        "require",
+        "__dirname",
+        "process",
+        "exports",
+        "console",
+        "Buffer",
+        "module"
+    ]
+}

--- a/index.js
+++ b/index.js
@@ -6,11 +6,11 @@ var _ = require('underscore'),
     log = require('bucker').createLogger(config.bucker, module);
 
 
-config.apis = _.extend({
+config.andyetAPIs = _.extend({
     'accounts': 'https://apps.andyet.com',
     'shippy': 'https://api.shippy.io',
     'talky': 'https://api.talky.io'
-}, config.apis || {});
+}, config.andyetAPIs || {});
 
 
 function AndYetMiddleware() {
@@ -48,9 +48,9 @@ function AndYetMiddleware() {
                 req.session.nextUrl = req.query.next;
             }
             req.session.save(function () {
-                var url = config.apis.accounts + '/oauth/authorize?' + querystring.stringify({
+                var url = config.andyetAPIs.accounts + '/oauth/authorize?' + querystring.stringify({
                     response_type: 'code',
-                    client_id: config.auth.id,
+                    client_id: config.andyetAuth.id,
                     state: req.session.oauthState
                 });
                 res.redirect(url);
@@ -71,13 +71,13 @@ function AndYetMiddleware() {
             }
 
             request.post({
-                url: config.apis.accounts + '/oauth/access_token',
+                url: config.andyetAPIs.accounts + '/oauth/access_token',
                 strictSSL: true,
                 form: {
                     code: result.code,
                     grant_type: 'authorization_code',
-                    client_id: config.auth.id,
-                    client_secret: config.auth.secret
+                    client_id: config.andyetAuth.id,
+                    client_secret: config.andyetAuth.secret
                 }
             }, function (err, res, body) {
                 if (res && res.statusCode === 200) {
@@ -126,7 +126,7 @@ function AndYetMiddleware() {
             next();
         } else {
             request.get({
-                url: config.apis[self.api] + '/me',
+                url: config.andyetAPIs[self.api] + '/me',
                 strictSSL: true,
                 headers: {
                     authorization: 'Bearer ' + req.token.access_token
@@ -156,12 +156,12 @@ function AndYetMiddleware() {
                 return res.redirect('/auth');
             } else {
                 request.post({
-                    url: config.apis.accounts + '/oauth/validate',
+                    url: config.andyetAPIs.accounts + '/oauth/validate',
                     strictSSL: true,
                     form: {
                         access_token: cookieToken,
-                        client_id: config.auth.id,
-                        client_secret: config.auth.secret,
+                        client_id: config.andyetAuth.id,
+                        client_secret: config.andyetAauth.secret,
                     }
                 }, function (err, res2, body) {
                     if (res2 && res2.statusCode === 200) {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,13 @@
   "description": "Dead simple &yet auth middleware.",
   "version": "0.0.12",
   "dependencies": {
+    "bucker": "0.4.0",
     "express": "3.x",
-    "colors": "0.6.0-1",
+    "getconfig": "0.0.5",
     "request": "2.21.0"
+  },
+  "devDependencies": {
+      "precommit-hook": "0.3.4"
   },
   "main": "index.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "andyet-express-auth",
   "description": "Dead simple &yet auth middleware.",
-  "version": "0.0.12",
+  "version": "0.1.0",
   "dependencies": {
     "bucker": "0.4.0",
     "express": "3.x",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "version": "0.1.0",
   "dependencies": {
     "bucker": "0.4.0",
-    "express": "3.x",
     "getconfig": "0.0.5",
     "request": "2.21.0"
   },
   "devDependencies": {
-      "precommit-hook": "0.3.4"
+    "express": "3.x",
+    "precommit-hook": "0.3.4"
   },
   "main": "index.js"
 }


### PR DESCRIPTION
This now assumes that *_config.json provides:

```
andyetAuth: {
  id: 'blah'
  secret: 'donttell'
},
andyetAPIs: { // this is for overriding production api urls for localhost variants
  accounts: 'localhost url if not using production'
  shippy: 'ditto',
  talky: 'ditto'
},
bucker: {bucker stuff}
```

And using it should look like:

```
app.use(andyetAuth.middleware(app, {
    api: 'talky',
    defaultRedirect: '/app'  
}));
```
