### PR TITLE
Fix typo, remove most dependencies for getconfig, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ var express = require('express'),
 // config our middleware
 app.use(express.cookieParser());
 app.use(express.session({ secret: 'keyboard cat' }));
-app.use(andyetAuth.middleware({
-    app: app,
-    clientId: '<< YOUR CLIENT ID>>',
-    clientSecret: '<< YOUR CLIENT SECRET>>',
-    defaultRedirect: '/secured'
+app.use(andyetAuth.middleware(app, {
+    id: '<< YOUR CLIENT ID>>',
+    secret: '<< YOUR CLIENT SECRET>>',
+    successRedirect: '/secured',
+    failedRedirect: '/didntauthorize'
 }));
 
 // Just re-direct people to '/auth' and the plugin does the rest.

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-var _ = require('underscore'),
-    config = require('getconfig'),
-    crypto = require('crypto'),
-    request = require('request'),
-    querystring = require('querystring'),
-    log = require('bucker').createLogger(config.bucker, module);
+var _ = require('underscore');
+var config = require('getconfig');
+var crypto = require('crypto');
+var request = require('request');
+var querystring = require('querystring');
+var log = require('bucker').createLogger(config.bucker, module);
 
 
 config.andyetAPIs = _.extend({
@@ -20,6 +20,16 @@ function AndYetMiddleware() {
         var self = this;
 
         self.app = app;
+
+        self.clientId = config.andyetAuth.id || opts.id;
+        self.clientSecret = config.andyetAuth.secret || opts.secret;
+
+        if (!self.clientId) {
+            log.error('Missing client ID');
+        }
+        if (!self.clientSecret) {
+            log.error('Missing client secret');
+        }
 
         if (!opts.successRedirect) {
             log.warn('Missing successRedirect in andyetAuth settings, using "/"');
@@ -165,7 +175,7 @@ function AndYetMiddleware() {
                     form: {
                         access_token: cookieToken,
                         client_id: config.andyetAuth.id,
-                        client_secret: config.andyetAauth.secret,
+                        client_secret: config.andyetAuth.secret,
                     }
                 }, function (err, res2, body) {
                     if (res2 && res2.statusCode === 200) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "bucker": "0.4.0",
     "getconfig": "0.0.5",
-    "request": "2.21.0"
+    "request": "2.21.0",
+    "underscore": "1.4.4"
   },
   "devDependencies": {
     "express": "3.x",


### PR DESCRIPTION
Still depends on bucker for now.

New use pattern:

```
app.use(andyetAuth.middleware(app, {
    id: config.andyetAuth.id,
    secret: config.andyetAuth.secret,
    andyetAPIs: config.andyetAPIs
});
```
